### PR TITLE
Add .babelrc to npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
 tmp
-
+.babelrc


### PR DESCRIPTION
This file is required for the package development but not consumers.

Having this file in npm causes errors for consumers like:

```
error: bundling failed: ReferenceError: Unknown plugin
"babel-plugin-transform-builtin-extend" specified in
"/AnchorX/node_modules/stellar-sdk/.babelrc"
at 0, attempted to resolve relative to
"/AnchorX/node_modules/stellar-sdk"
```

The same problem has been discovered in other projects. See:

 - https://github.com/react-community/react-native-maps/issues/1206
 - https://github.com/brigade/react-waypoint/issues/186#issuecomment-298507276
 - https://github.com/react-community/react-native-maps/pull/1246